### PR TITLE
Add Gitlab CI configuration to starters/blog

### DIFF
--- a/starters/blog/.gitlab-ci.yml
+++ b/starters/blog/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 pages:
-  stage: test
+  stage: deploy
   image: node:latest
   cache:
     paths: ["node_modules"]

--- a/starters/blog/.gitlab-ci.yml
+++ b/starters/blog/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+pages:
+  stage: test
+  image: node:latest
+  cache:
+    paths: ["node_modules"]
+  script: 
+    - npm install
+    - npm run build
+  artifacts:
+    expire_in: 1 days
+    paths:
+      - public


### PR DESCRIPTION
## Description

Adds a basic gitlab configuration which deploys the page on gitlab pages.
This is ideal for testing purposes and for users who do not know how to setup a gitlab pipeline.

### Documentation

https://docs.gitlab.com/ee/ci/

### Tests

no

## Related Issues

none
